### PR TITLE
Replace yajl-ruby with the json gem for JSON handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -986,7 +986,8 @@ compression_level best_compression
 
 ### prefer_oj_serializer
 
-With default behavior, Elasticsearch client uses `Yajl` as JSON encoder/decoder.
+With default behavior, Elasticsearch client uses `JSON` as JSON encoder/decoder.
+(Changed using library from `Yajl` to `JSON` at 6.0.1).
 `Oj` is the alternative high performance JSON encoder/decoder.
 When this parameter sets as `true`, Elasticsearch client uses `Oj` as JSON encoder/decoder.
 

--- a/lib/fluent/plugin/elasticsearch_index_lifecycle_management.rb
+++ b/lib/fluent/plugin/elasticsearch_index_lifecycle_management.rb
@@ -76,6 +76,6 @@ module Fluent::Plugin::ElasticsearchIndexLifecycleManagement
 
   def default_policy_payload
     default_policy_path = File.join(__dir__, ILM_DEFAULT_POLICY_PATH)
-    Yajl.load(::IO.read(default_policy_path))
+    JSON.parse(::IO.read(default_policy_path))
   end
 end

--- a/lib/fluent/plugin/in_elasticsearch.rb
+++ b/lib/fluent/plugin/in_elasticsearch.rb
@@ -272,7 +272,7 @@ module Fluent::Plugin
     def run_slice(slice_id=nil)
       slice_query = @base_query
       slice_query = slice_query.merge('slice' => { 'id' => slice_id, 'max' => @num_slices}) unless slice_id.nil?
-      result = client.search(@options.merge(:body => Yajl.dump(slice_query) ))
+      result = client.search(@options.merge(:body => JSON.generate(slice_query) ))
       es = Fluent::MultiEventStream.new
 
       result["hits"]["hits"].each {|hit| process_events(hit, es)}

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -296,7 +296,7 @@ EOC
           Elasticsearch::API.settings[:serializer] = Fluent::Plugin::Serializer::Oj
         end
       rescue LoadError
-        @dump_proc = Yajl.method(:dump)
+        @dump_proc = JSON.method(:generate)
       end
 
       raise Fluent::ConfigError, "`cloud_auth` must be present if `cloud_id` is present" if @cloud_id && @cloud_auth.nil?
@@ -954,7 +954,7 @@ EOC
             {"_index" => {"order" => "desc"}}
          ]
         }
-        result = client.search(options.merge(:body => Yajl.dump(query)))
+        result = client.search(options.merge(:body => JSON.generate(query)))
         # There should be just one hit per _id, but in case there still is multiple, just the oldest index is stored to map
         result['hits']['hits'].each do |hit|
           indices[hit["_id"]] = hit["_index"]


### PR DESCRIPTION
This commit replaces the `yajl-ruby` dependency with Ruby's standard `json` gem for the following reasons:

1. Future Compatibility: `yajl-ruby` is no longer actively maintained and relies on internal C APIs that are removed in Ruby 4.1. Migrating to the standard `json` gem ensures the plugin can continue to be built and used in future Ruby environments. Ref. https://github.com/ruby/ruby/pull/15447, https://github.com/brianmario/yajl-ruby/issues/233
2. Performance: The standard `json` gem has seen significant improvements in recent updates and now outperforms `yajl-ruby`.

```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'benchmark-ips'
  gem 'yajl-ruby', require: 'yajl'
  gem 'json'
end

Benchmark.ips do |x|
  json = '{"a":"Alpha","b":true,"c":12345,"d":[true,[false,[-123456789,null],3.9676,["Something else.",false],null]],"e":{"zero":null,"one":1,"two":2,"three":[3],"four":[0,1,2,3,4]},"f":null,"h":{"a":{"b":{"c":{"d":{"e":{"f":{"g":null}}}}}}},"i":[[[[[[[null]]]]]]]}'

  x.report('Yajl.load') {
    Yajl.load(json)
  }
  x.report('JSON.parse') {
    JSON.parse(json)
  }

  x.compare!
end
```

```
ruby 4.0.5 (2026-05-20 revision 64336ffd0e) +PRISM [x86_64-linux]
Warming up --------------------------------------
           Yajl.load    20.019k i/100ms
          JSON.parse    80.144k i/100ms
Calculating -------------------------------------
           Yajl.load    202.875k (± 0.2%) i/s    (4.93 μs/i) -      1.021M in   5.032515s
          JSON.parse    808.103k (± 0.2%) i/s    (1.24 μs/i) -      4.087M in   5.057949s

Comparison:
JSON.parse:   808103.0 i/s
 Yajl.load:   202874.5 i/s - 3.98x  slower
```

DESCRIPTION HERE

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
